### PR TITLE
Priority 1 Fixes

### DIFF
--- a/app/controllers/found_people_controller.rb
+++ b/app/controllers/found_people_controller.rb
@@ -5,7 +5,6 @@ class FoundPeopleController < ApplicationController
       last_name: params['last_name'],
       location: params['location'],
       birthday: params['birthday'],
-      status: params['status'],
     }
 
     @people = FoundPerson.all
@@ -13,6 +12,5 @@ class FoundPeopleController < ApplicationController
     @people = @people.where('last_name like ?', "#{params['last_name']}%") if params['last_name'].present?
     @people = @people.where('location like ?', "#{params['location']}") if params['location'].present?
     @people = @people.where('birthday = ?', params['birthday'].to_datetime) if params['birthday'].present?
-    @people = @people.where('status like ?', "#{params['status']}") if params['status'].present?
   end
 end

--- a/app/models/concerns/text_parser_commands.rb
+++ b/app/models/concerns/text_parser_commands.rb
@@ -5,16 +5,16 @@ module TextParserCommands
     when :en
       'find'
     when :es
-      'descubrir'
+      'busco'
     end
   end
 
   def report(language)
     case language
     when :en
-      'report'
+      'register'
     when :es
-      'busco'
+      'registrar'
     end
   end
   

--- a/app/models/text_parser.rb
+++ b/app/models/text_parser.rb
@@ -136,7 +136,7 @@ class TextParser
   
   # Simple american date parsing just give it over to rails
   def self.parse_birthday(date_string)
-    date = Date.strptime(date_string.tr('-.','/'), "%m/%d/%Y") rescue nil
+    date = Date.strptime(date_string.tr('-.','/'), "%d/%m/%Y") rescue nil
     date ||= Date.parse(date_string) rescue nil
     date
   end

--- a/app/services/message_processor.rb
+++ b/app/services/message_processor.rb
@@ -52,7 +52,7 @@ class MessageProcessor
   end
 
   def unknown_message_type
-    " Usar: 'Busco [nombres] [apellidos] en [ciudad] nació[mm-dd-aaaa]' o" \
+    " Usar: 'Busco [nombres] [apellidos] en [ciudad] nació[dd-mm-aaaa]' o" \
     " 'Descubrir [nombres] [apellidos] en [ciudad]'"
   end
 end

--- a/app/services/message_processor.rb
+++ b/app/services/message_processor.rb
@@ -52,7 +52,6 @@ class MessageProcessor
   end
 
   def unknown_message_type
-    "Error en formato." \
     " Usar: 'Busco [nombres] [apellidos] en [ciudad] nació[mm-dd-aaaa]' o" \
     " 'Descubrir [nombres] [apellidos] en [ciudad]'"
   end

--- a/app/views/found_people/show.html.erb
+++ b/app/views/found_people/show.html.erb
@@ -22,7 +22,6 @@
     <th>Last Name</th>
     <th>Location</th>
     <th>Birthday</th>
-    <th>Status</th>
   </tr>
  
 <% @people.each do |person| %>
@@ -31,7 +30,6 @@
     <td><%= person.last_name %></td>
     <td><%= person.location %></td>
     <td><%= person.birthday %></td>
-    <td><%= person.status %></td>
   </tr>
   <% @current_class = @current_class.blank? ? 'alt-row' : '' %>
 <% end %>

--- a/spec/models/text_parser_spec.rb
+++ b/spec/models/text_parser_spec.rb
@@ -233,7 +233,7 @@ describe TextParser do
       let!(:date_object) {Date.today}
       let(:date_string) {""}
       ['/','-','.'].each do |separator|
-        ["%m#{separator}%d#{separator}%Y", "%m#{separator}%d#{separator}%Y"].each do |format|
+        ["%d#{separator}%m#{separator}%Y", "%d#{separator}%m#{separator}%Y"].each do |format|
           it "gets date for '#{format}'" do
             date_string = date_object.strftime(format)
             expect(TextParser.parse_birthday(date_string)).to eq(date_object)

--- a/spec/models/text_parser_spec.rb
+++ b/spec/models/text_parser_spec.rb
@@ -5,7 +5,7 @@ describe TextParser do
     describe '.parse_message(text_message)' do
       let(:fake_hash) {{:something => :here}}
       context 'for reporting' do
-        let(:message) { "report this is just test data"}
+        let(:message) { "register this is just test data"}
         it 'should call parse_report' do
           allow(TextParser).to receive(:parse_report).and_return(fake_hash)
           expect(TextParser).to receive(:parse_report).once
@@ -35,7 +35,7 @@ describe TextParser do
       let(:date_string) {"01/01/1998"}
       context 'with valid text' do
         context 'with everything' do
-          let(:text_message) {"report Billy Bob Joe in City Name, Place born #{date_string} status Pretty Good 👍"}
+          let(:text_message) {"register Billy Bob Joe in City Name, Place born #{date_string} status Pretty Good 👍"}
           it "should return expected hash" do
             result = TextParser.parse_report(text_message, :en)
             expect(result[:first_name]).to eq("Billy")
@@ -46,7 +46,7 @@ describe TextParser do
           end
         end
         context 'without a birthday' do
-          let(:text_message) {"report Billy Bob Joe in City Name, Place status Pretty Good 👍"}
+          let(:text_message) {"register Billy Bob Joe in City Name, Place status Pretty Good 👍"}
           it "should return expected hash" do
             result = TextParser.parse_report(text_message, :en)
             expect(result[:first_name]).to eq("Billy")
@@ -57,7 +57,7 @@ describe TextParser do
           end
         end
         context 'without a status' do
-          let(:text_message) {"report Billy Bob Joe in City Name, Place born #{date_string}"}
+          let(:text_message) {"register Billy Bob Joe in City Name, Place born #{date_string}"}
           it "should return expected hash" do
             result = TextParser.parse_report(text_message, :en)
             expect(result[:first_name]).to eq("Billy")
@@ -68,7 +68,7 @@ describe TextParser do
           end
         end
         context 'without birthday or status' do
-          let(:text_message) {"report Billy Bob Joe in City Name, Place"}
+          let(:text_message) {"register Billy Bob Joe in City Name, Place"}
           it "should return expected hash" do
             result = TextParser.parse_report(text_message, :en)
             expect(result[:first_name]).to eq("Billy")
@@ -81,7 +81,7 @@ describe TextParser do
       end
       context 'with invalid text' do
         context 'with blank name' do
-          let(:text_message) {"report in City Name, Place born #{date_string} status Pretty Good 👍"}
+          let(:text_message) {"register in City Name, Place born #{date_string} status Pretty Good 👍"}
           it "first_name and last_name should be_blank" do
             result = TextParser.parse_report(text_message, :en)
             expect(result[:first_name]).to be_blank
@@ -89,7 +89,7 @@ describe TextParser do
           end
         end
         context 'with no location' do
-          let(:text_message) {"report Billy Bob Joe born #{date_string} status Pretty Good 👍"}
+          let(:text_message) {"register Billy Bob Joe born #{date_string} status Pretty Good 👍"}
           it "location should be_blank" do
             result = TextParser.parse_report(text_message, :en)
             expect(result[:location]).to be_blank

--- a/spec/services/message_processor_spec.rb
+++ b/spec/services/message_processor_spec.rb
@@ -46,7 +46,7 @@ describe MessageProcessor do
       )
 
       expect(result).to eq( 
-        " Usar: 'Busco [nombres] [apellidos] en [ciudad] nació[mm-dd-aaaa]' o" \
+        " Usar: 'Busco [nombres] [apellidos] en [ciudad] nació[dd-mm-aaaa]' o" \
         " 'Descubrir [nombres] [apellidos] en [ciudad]'")
     end
   end

--- a/spec/services/message_processor_spec.rb
+++ b/spec/services/message_processor_spec.rb
@@ -46,7 +46,6 @@ describe MessageProcessor do
       )
 
       expect(result).to eq( 
-        "Error en formato." \
         " Usar: 'Busco [nombres] [apellidos] en [ciudad] nació[mm-dd-aaaa]' o" \
         " 'Descubrir [nombres] [apellidos] en [ciudad]'")
     end

--- a/spec/services/message_processor_spec.rb
+++ b/spec/services/message_processor_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 describe MessageProcessor do
-  context "reporting person found" do
+  context "registering person found" do
     it "should process and return a supportive message" do
       expect(FoundPerson).to receive(:create!)
 
       result = MessageProcessor.process_message(
-        message: "Report Jane Doe in Uptown born 01-01-1990",
+        message: "register Jane Doe in Uptown born 01-01-1990",
         sender: "7875557777",
       )
 


### PR DESCRIPTION
Includes

- Remove "status" as a visible column
- Change words "busco" and "descubrir." Let's use "Registrar/Register" for when someone wants to log into the registry and "Busco/Find" for when someone wants to find someone.
- birthday format to be dd-mm-yyyy
- remove "error message"

does not include:
- Registered people should not auto load